### PR TITLE
qm: memory: fix alignment issue

### DIFF
--- a/qm.adoc
+++ b/qm.adoc
@@ -703,8 +703,8 @@ database VM when spare RAM is available. For this you assign a Shares property
 of 3000 to the database VM, leaving the other VMs to the Shares default setting
 of 1000. The host server has 32GB of RAM, and is currently using 16GB, leaving 32
 * 80/100 - 16 = 9GB RAM to be allocated to the VMs on top of their configured
-minimum memory amount. The database VM will benefit from 9 * 3000 / (3000 +
-1000 + 1000 + 1000) = 4.5 GB extra RAM and each HTTP server from 1.5 GB.
+minimum memory amount. The database VM will benefit from 9 * 3000 / (3000 
++ 1000 + 1000 + 1000) = 4.5 GB extra RAM and each HTTP server from 1.5 GB.
 
 All Linux distributions released after 2010 have the balloon kernel driver
 included. For Windows OSes, the balloon driver needs to be added manually and can


### PR DESCRIPTION
Remove the unwanted new line caused by the space and the '+' at the end of a line.
I am aware that this is a mirror, but I would appreciate it if you could make the corresponding changes in the repo.
It would make the document more readable and avoid confusion.