### PR TITLE
Correct code formatting of vxlan-and-evpn.adoc

### DIFF
--- a/vxlan-and-evpn.adoc
+++ b/vxlan-and-evpn.adoc
@@ -2030,7 +2030,7 @@ router bgp 25253
  exit-address-family
  !
 !
----
+----
 
 Route Reflectors
 ^^^^^^^^^^^^^^^^
@@ -2064,7 +2064,7 @@ router bgp 1234
   !
   exit
 !
----
+----
 
 rrserver2
 ----
@@ -2087,7 +2087,7 @@ router bgp 1234
   !
   exit
 !
----
+----
 
 proxmoxnode(s)
 ----


### PR DESCRIPTION
There were a couple of hyphens missing from code blocks in the "Route Reflectors" section that prevented the documents from rendering properly.